### PR TITLE
Fixed video scraping

### DIFF
--- a/video_scrapping.sh
+++ b/video_scrapping.sh
@@ -15,75 +15,37 @@ episode_list () {
 generate_link() {
     case $1 in
 	1)
-	    provider_name='Mp4upload'
-	    refr=$(printf "%s" "$al_links" | grep "mp4upload")
-	    [ -z "$refr" ] && refr=$(printf "%s" "$resp" | grep "mp4upload")
-	    [ -z "$refr" ] && return 0
-	    result_links="$(curl -A "$agent" -s "$refr" -H "DNT: 1" -L |
-				sed -nE 's_.*embed\|(.*)\|.*blank.*\|(.*)\|(.*)\|(.*)\|(.*)\|src.*_https://\1.mp4upload.com:\5/d/\4/\3.\2_p')"
-	    ;;
-	2)
-	    provider_name='Doodstream'
-	    dood_id=$(printf "%s" "$al_links" | sed -n "s_.*dood.*/e/__p")
-	    [ -z "$dood_id" ] && dood_id=$(printf "%s" "$resp" | sed -n "s_.*dood.*/e/__p")
-	    refr="https://dood.pm/e/$dood_id"
-	    [ -z "$dood_id" ] || dood_md5=$(curl -A "$agent" -s "$refr" --max-time 10 | sed -nE "s|.*'(.*pass_md5.*)', func.*|\1|p")
-	    [ -z "$dood_md5" ] && return 0
-	    result_links="$(curl -A "$agent" -s "https://dood.pm${dood_md5}" -e "$refr" || true)doodstream?token=$(printf "%s" "$dood_md5" | cut -d'/' -f4 || true)&expiry=$(date +%s)000"
-	    ;;
-	3)
-	    provider_name='Streamlare'
-	    lare_id=$(printf "%s" "$al_links" | sed -nE 's_.*streamlare.*/e/(.*)_\1_p')
-	    [ -z "$lare_id" ] && lare_id=$(printf "%s" "$dpage_url" | sed -nE 's_.*streamlare.*/e/(.*)_\1_p')
-	    refr="https://streamlare.com/e/$lare_id"
-	    [ -z "$lare_id" ] && return 0
-	    lare_token=$(curl -s -A "$agent" "$refr" -L | sed -nE 's/.*csrf-token.*content="(.*)">/\1/p')
-	    [ -z "$lare_token" ] || result_links="$(curl -s -A "$agent" -H "x-requested-with:XMLHttpRequest" -X POST "https://streamlare.com/api/video/download/get" -d "{\"id\":\"$lare_id\"}" \
-				-H "x-csrf-token:$lare_token" -H "content-type:application/json;charset=UTF-8" | sed 's/\\//g' | sed -nE 's/.*url":"([^"]*)".*/\1/p')"
-	    ;;
-	4)
-	    provider_name='Okru'
-	    ok_id=$(printf "%s" "$al_links" | sed -nE 's_.*ok.*videoembed/(.*)_\1_p')
-	    [ -z "$ok_id" ] && ok_id=$(printf "%s" "$dpage_url" | sed -nE 's_.*ok.*videoembed/(.*)_\1_p')
-	    refr="https://odnoklassniki.ru/videoembed/$ok_id"
-	    [ -z "$ok_id" ] && return 0
-	    result_links="$(curl -s "$refr" | sed -nE 's_.*data-options="([^"]*)".*_\1_p' | sed -e 's/&quot;/"/g' -e 's/\u0026/\&/g' -e 's/amp;//g' | sed 's/\\//g' | sed -nE 's/.*videos":(.*),"metadataE.*/\1/p' | tr '{|}' '\n' |
-				sed -nE 's/"name":"mobile","url":"(.*)",.*/144p >\1/p ;
-						s/"name":"lowest","url":"(.*)",.*/240p >\1/p ;
-						s/"name":"low","url":"(.*)",.*/360p >\1/p ;
-						s/"name":"sd","url":"(.*)",.*/480p >\1/p ;
-						s/"name":"hd","url":"(.*)",.*/720p >\1/p ;
-						s/"name":"full","url":"(.*)",.*/1080p >\1/p')"
-	    ;;
-	5)
 	    provider_name='Xstreamcdn'
-	    fb_id=$(printf "%s" "$resp" | sed -n "s_.*fembed.*/v/__p")
-	    refr="https://fembed-hd.com/v/$fb_id"
-	    [ -z "$fb_id" ] && return 0
-	    result_links="$(curl -A "$agent" -s -X POST "https://fembed-hd.com/api/source/$fb_id" -H "x-requested-with:XMLHttpRequest" |
+			progress "Fetching $provider_name links.."
+			fb_id=$(printf "%s" "$resp" | sed -n "s_.*fembed.*/v/__p")
+			refr="https://fembed-hd.com/v/$fb_id"
+			[ -z "$fb_id" ] && return 0
+			result_links="$(curl -A "$agent" -s -X POST "https://fembed-hd.com/api/source/$fb_id" -H "x-requested-with:XMLHttpRequest" |
 				sed -e 's/\\//g' -e 's/.*data"://' | tr "}" "\n" | sed -nE 's/.*file":"(.*)","label":"(.*)","type.*/\2>\1/p')"
-	    ;;
-	6)
+			;;
+	2)
 	    provider_name='Animixplay'
-	    refr="$base_url"
-	    [ -z "$id" ] && return 0
-	    enc_id=$(printf "%s" "$id" | base64)
-	    ani_id=$(printf "%sLTXs3GrU8we9O%s" "$id" "$enc_id" | base64)
-	    result_links="$(curl -s "$base_url/api/live${ani_id}" -A "$agent" -I | sed -nE 's_location: (.*)_\1_p' | cut -d"#" -f2 | base64 -d)"
-	    ;;
+			progress "Fetching $provider_name Direct link.."
+			refr="$base_url"
+			[ -z "$id" ] && return 0
+			enc_id=$(printf "%s" "$id" | base64)
+			ani_id=$(printf "%sLTXs3GrU8we9O%s" "$id" "$enc_id" | base64)
+			result_links="$(curl -s "$base_url/api/live${ani_id}" -A "$agent" -I | sed -nE 's_location: (.*)_\1_p' | cut -d"#" -f2 | base64 -d)"
+			;;
 	*)
 	    provider_name='Gogoanime'
-	    refr="https://goload.pro"
-	    [ -z "$id" ] && return 0
-	    secret_key=$(printf "%s" "$resp" | sed -n '2p' | tr -d "\n" | od -A n -t x1 | tr -d " |\n")
-	    iv=$(printf "%s" "$resp" | sed -n '3p' | tr -d "\n" | od -A n -t x1 | tr -d " |\n")
-	    second_key=$(printf "%s" "$resp" | sed -n '4p' | tr -d "\n" | od -A n -t x1 | tr -d " |\n")
-	    token=$(printf "%s" "$resp" | head -1 | base64 -d | openssl enc -d -aes256 -K "$secret_key" -iv "$iv" | sed -nE 's/.*&(token.*)/\1/p')
-	    ajax=$(printf '%s' "$id" | openssl enc -e -aes256 -K "$secret_key" -iv "$iv" -a)
-	    data=$(curl -A "$agent" -s -H "X-Requested-With:XMLHttpRequest" "https://goload.pro/encrypt-ajax.php?id=${ajax}&alias=${id}&${token}" | sed -e 's/{"data":"//' -e 's/"}/\n/' -e 's/\\//g')
-	    result_links="$(printf '%s' "$data" | base64 -d 2>/dev/null | openssl enc -d -aes256 -K "$second_key" -iv "$iv" 2>/dev/null |
+			progress "Fetching $provider_name Direct link.."
+			refr="$gogohd_url"
+			[ -z "$id" ] && return 0
+			secret_key=$(printf "%s" "$resp" | sed -n '2p' | tr -d "\n" | od -A n -t x1 | tr -d " |\n")
+			iv=$(printf "%s" "$resp" | sed -n '3p' | tr -d "\n" | od -A n -t x1 | tr -d " |\n")
+			second_key=$(printf "%s" "$resp" | sed -n '4p' | tr -d "\n" | od -A n -t x1 | tr -d " |\n")
+			token=$(printf "%s" "$resp" | head -1 | base64 -d | openssl enc -d -aes256 -K "$secret_key" -iv "$iv" | sed -nE 's/.*&(token.*)/\1/p')
+			ajax=$(printf '%s' "$id" | openssl enc -e -aes256 -K "$secret_key" -iv "$iv" -a)
+			data=$(curl -A "$agent" -sL -H "X-Requested-With:XMLHttpRequest" "${gogohd_url}encrypt-ajax.php?id=${ajax}&alias=${id}&${token}" | sed -e 's/{"data":"//' -e 's/"}/\n/' -e 's/\\//g')
+			result_links="$(printf '%s' "$data" | base64 -d 2>/dev/null | openssl enc -d -aes256 -K "$second_key" -iv "$iv" 2>/dev/null |
 				sed -e 's/\].*/\]/' -e 's/\\//g' | grep -Eo 'https:\/\/[-a-zA-Z0-9@:%._\+~#=][a-zA-Z0-9][-a-zA-Z0-9@:%_\+.~#?&\/\/=]*')"
-	    ;;
+			;;
     esac
 }
 


### PR DESCRIPTION
Since the video servers have changed since July, the video scraping does not work for the current version of Enime. I copied the video scraping parameters from ani-cli, which allowed Enime to play episodes. TL;DR fixed video server parameters